### PR TITLE
Integrate NativeWind v4 with Expo and TypeScript

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,8 +1,10 @@
+import "./global.css"; // Añadido
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import RecordScreen from './src/screen/RecordScreen';
-import 'nativewind/types';
+// import 'nativewind/types'; // Eliminado - se gestionará con nativewind-env.d.ts
+import { View, Text } from 'react-native'; // Asegurarse que View y Text estén importados
 
 export type RootStackParamList = {
   Record: undefined;
@@ -12,10 +14,22 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function App() {
   return (
-    <NavigationContainer>
-      <Stack.Navigator initialRouteName="Record">
-        <Stack.Screen name="Record" component={RecordScreen} options={{ title: 'Grabadora de Voz' }} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <View className="flex-1 bg-neutral-800"> {/* View de prueba con Tailwind */}
+      {/* Texto de prueba para asegurar que las clases de texto también funcionan */}
+      <Text className="text-center text-2xl text-white pt-12">Probando NativeWind</Text>
+      <NavigationContainer>
+        <Stack.Navigator initialRouteName="Record">
+          <Stack.Screen
+            name="Record"
+            component={RecordScreen}
+            options={{
+              title: 'Grabadora de Voz',
+              headerStyle: { backgroundColor: '#333' }, // Ejemplo de estilo de header
+              headerTitleStyle: { color: '#fff' }
+            }}
+          />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </View>
   );
 }

--- a/app.json
+++ b/app.json
@@ -23,7 +23,8 @@
       "edgeToEdgeEnabled": true
     },
     "web": {
-      "favicon": "./assets/favicon.png"
+      "favicon": "./assets/favicon.png",
+      "bundler": "metro"
     }
   }
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,9 @@
 module.exports = function (api) {
   api.cache(true);
   return {
-    presets: ['babel-preset-expo'],
+    presets: [
+      ["babel-preset-expo", { jsxImportSource: "nativewind" }],
+      "nativewind/babel",
+    ],
   };
 };

--- a/global.css
+++ b/global.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,8 @@
+// Learn more https://docs.expo.dev/guides/customizing-metro
+const { getDefaultConfig } = require("expo/metro-config");
+const { withNativeWind } = require('nativewind/metro');
+
+/** @type {import('expo/metro-config').MetroConfig} */
+const config = getDefaultConfig(__dirname);
+
+module.exports = withNativeWind(config, { input: './global.css' });

--- a/nativewind-env.d.ts
+++ b/nativewind-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="nativewind/types" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react": "19.0.0",
         "react-native": "0.79.4",
         "react-native-dotenv": "^3.4.11",
+        "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1"
       },
@@ -7794,11 +7795,10 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.18.0.tgz",
-      "integrity": "sha512-eVcNcqeOkMW+BUWAHdtvN3FKgC8J8wiEJkX6bNGGQaLS7m7e4amTfjIcqf/Ta+lerZLurmDaQ0lICI1CKPrb1Q==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.5.tgz",
+      "integrity": "sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -7824,7 +7824,6 @@
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
       "integrity": "sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "19.0.0",
     "react-native": "0.79.4",
     "react-native-dotenv": "^3.4.11",
+    "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1"
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    "./App.{js,jsx,ts,tsx}",
+    "./App.tsx",
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
+  presets: [require("nativewind/preset")],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
- Update babel.config.js to use nativewind/babel as a preset and configure jsxImportSource.
- Update tailwind.config.js with NativeWind v4 preset and content paths.
- Add react-native-reanimated dependency as required by NativeWind.
- Create global.css with Tailwind directives.
- Create and configure metro.config.js for NativeWind.
- Update app.json to ensure Metro bundler for web.
- Create nativewind-env.d.ts for global TypeScript types.
- Modify App.tsx to import global.css and include test styles.